### PR TITLE
Implement Bluetooth LE transport for CLI on Linux

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -48,3 +48,12 @@ simulation-server:test:
     - (cd DistributedChatSimulationServer && swift test)
   needs:
     - simulation-server:build
+
+app:build:
+  stage: build-exes
+  tags:
+    - macos
+  script:
+    - xcodebuild build -scheme DistributedChatApp -sdk iphonesimulator -destination "platform=iOS Simulator,name=iPhone 11,OS=14.3"
+  needs:
+    - distributed-chat:build

--- a/DistributedChat/Sources/DistributedChat/Controller/ChatController.swift
+++ b/DistributedChat/Sources/DistributedChat/Controller/ChatController.swift
@@ -156,6 +156,10 @@ public class ChatController {
     private func update(logicalClock: Int) {
         me.logicalClock = max(me.logicalClock, logicalClock) + 1
     }
+
+    public func update(me: ChatUser) {
+        self.me = me
+    }
     
     public func update(name: String) {
         me.name = name

--- a/DistributedChatCLI/Package.resolved
+++ b/DistributedChatCLI/Package.resolved
@@ -56,6 +56,15 @@
         }
       },
       {
+        "package": "GATT",
+        "repositoryURL": "https://github.com/fwcd/swift-gatt.git",
+        "state": {
+          "branch": null,
+          "revision": "9b742fa388d12af0959984f015e6e18c35b1dba1",
+          "version": null
+        }
+      },
+      {
         "package": "swift-log",
         "repositoryURL": "https://github.com/apple/swift-log.git",
         "state": {

--- a/DistributedChatCLI/Package.resolved
+++ b/DistributedChatCLI/Package.resolved
@@ -60,7 +60,7 @@
         "repositoryURL": "https://github.com/fwcd/swift-gatt.git",
         "state": {
           "branch": null,
-          "revision": "9b742fa388d12af0959984f015e6e18c35b1dba1",
+          "revision": "787c31bcb5da3b3217b1400cce56cda00f6df1e0",
           "version": null
         }
       },

--- a/DistributedChatCLI/Package.resolved
+++ b/DistributedChatCLI/Package.resolved
@@ -2,6 +2,24 @@
   "object": {
     "pins": [
       {
+        "package": "Bluetooth",
+        "repositoryURL": "https://github.com/PureSwift/Bluetooth.git",
+        "state": {
+          "branch": "master",
+          "revision": "308277c808ced9ab169f52cb911b593c96b6fd27",
+          "version": null
+        }
+      },
+      {
+        "package": "BluetoothLinux",
+        "repositoryURL": "https://github.com/PureSwift/BluetoothLinux.git",
+        "state": {
+          "branch": null,
+          "revision": "e9dd7332b5ac92c09d3d9ff9244ac535afc5f493",
+          "version": null
+        }
+      },
+      {
         "package": "LineNoise",
         "repositoryURL": "https://github.com/andybest/linenoise-swift.git",
         "state": {

--- a/DistributedChatCLI/Package.swift
+++ b/DistributedChatCLI/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.3.2"),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.1.2"),
         .package(url: "https://github.com/PureSwift/BluetoothLinux.git", .revision("e9dd7332b5ac92c09d3d9ff9244ac535afc5f493")),
-        // TODO: Use upstream again once PR is merged
+        // TODO: Use upstream again once https://github.com/PureSwift/GATT/issues/24 is merged
         // .package(url: "https://github.com/PureSwift/GATT.git", .revision("c3bbda8000e3b82486ca9a353725d1bfbc7701e8")),
         .package(name: "GATT", url: "https://github.com/fwcd/swift-gatt.git", .revision("9b742fa388d12af0959984f015e6e18c35b1dba1")),
         .package(name: "LineNoise", url: "https://github.com/andybest/linenoise-swift.git", .revision("78e9bc9b685ffd551af0f3ac4d6e2beb22afd33b")),

--- a/DistributedChatCLI/Package.swift
+++ b/DistributedChatCLI/Package.swift
@@ -17,6 +17,7 @@ let package = Package(
         .package(path: "../DistributedChatSimulationProtocol"),
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.3.2"),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.1.2"),
+        .package(url: "https://github.com/PureSwift/BluetoothLinux.git", .revision("e9dd7332b5ac92c09d3d9ff9244ac535afc5f493")),
         .package(name: "LineNoise", url: "https://github.com/andybest/linenoise-swift.git", .revision("78e9bc9b685ffd551af0f3ac4d6e2beb22afd33b")),
     ],
     targets: [

--- a/DistributedChatCLI/Package.swift
+++ b/DistributedChatCLI/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
                 .product(name: "DistributedChatSimulationProtocol", package: "DistributedChatSimulationProtocol"),
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "WebSocketKit", package: "websocket-kit"),
+                .product(name: "BluetoothLinux", package: "BluetoothLinux"),
                 .product(name: "LineNoise", package: "LineNoise"),
             ]
         )

--- a/DistributedChatCLI/Package.swift
+++ b/DistributedChatCLI/Package.swift
@@ -18,6 +18,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.3.2"),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.1.2"),
         .package(url: "https://github.com/PureSwift/BluetoothLinux.git", .revision("e9dd7332b5ac92c09d3d9ff9244ac535afc5f493")),
+        // TODO: Use upstream again once PR is merged
+        // .package(url: "https://github.com/PureSwift/GATT.git", .revision("c3bbda8000e3b82486ca9a353725d1bfbc7701e8")),
+        .package(name: "GATT", url: "https://github.com/fwcd/swift-gatt.git", .revision("9b742fa388d12af0959984f015e6e18c35b1dba1")),
         .package(name: "LineNoise", url: "https://github.com/andybest/linenoise-swift.git", .revision("78e9bc9b685ffd551af0f3ac4d6e2beb22afd33b")),
     ],
     targets: [
@@ -31,6 +34,7 @@ let package = Package(
                 .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "WebSocketKit", package: "websocket-kit"),
                 .product(name: "BluetoothLinux", package: "BluetoothLinux"),
+                .product(name: "GATT", package: "GATT"),
                 .product(name: "LineNoise", package: "LineNoise"),
             ]
         )

--- a/DistributedChatCLI/Package.swift
+++ b/DistributedChatCLI/Package.swift
@@ -18,9 +18,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "0.3.2"),
         .package(url: "https://github.com/vapor/websocket-kit.git", from: "2.1.2"),
         .package(url: "https://github.com/PureSwift/BluetoothLinux.git", .revision("e9dd7332b5ac92c09d3d9ff9244ac535afc5f493")),
-        // TODO: Use upstream again once https://github.com/PureSwift/GATT/issues/24 is merged
+        // TODO: Use upstream again once https://github.com/PureSwift/GATT/issues/24 and https://github.com/PureSwift/GATT/pull/27 are merged
         // .package(url: "https://github.com/PureSwift/GATT.git", .revision("c3bbda8000e3b82486ca9a353725d1bfbc7701e8")),
-        .package(name: "GATT", url: "https://github.com/fwcd/swift-gatt.git", .revision("9b742fa388d12af0959984f015e6e18c35b1dba1")),
+        .package(name: "GATT", url: "https://github.com/fwcd/swift-gatt.git", .revision("787c31bcb5da3b3217b1400cce56cda00f6df1e0")),
         .package(name: "LineNoise", url: "https://github.com/andybest/linenoise-swift.git", .revision("78e9bc9b685ffd551af0f3ac4d6e2beb22afd33b")),
     ],
     targets: [

--- a/DistributedChatCLI/Sources/DistributedChatCLI/ChatREPL.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/ChatREPL.swift
@@ -12,12 +12,12 @@ class ChatREPL {
     private let commandPrefix: String
     private var commands: [String: () -> Void]!
     
-    init(transport: ChatTransport, name: String, commandPrefix: String = ".") {
+    init(transport: ChatTransport, me: ChatUser, commandPrefix: String = ".") {
         self.transport = transport
         self.commandPrefix = commandPrefix
 
         controller = ChatController(transport: transport)
-        controller.update(name: name)
+        controller.update(me: me)
 
         controller.onAddChatMessage { [unowned self] msg in
             print("\r[\(displayName(of: msg.channel))] \(msg.author.displayName): \(msg.displayContent)\r")

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxError.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxError.swift
@@ -1,4 +1,6 @@
 public enum BluetoothLinuxError: Error {
     case noHostController
+    case noServices
+    case noCharacteristics
     case bleScanFailed(String)
 }

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxError.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxError.swift
@@ -1,0 +1,3 @@
+public enum BluetoothLinuxError: Error {
+    case noHostController
+}

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxError.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxError.swift
@@ -1,3 +1,4 @@
 public enum BluetoothLinuxError: Error {
     case noHostController
+    case bleScanFailed(String)
 }

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxError.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxError.swift
@@ -1,5 +1,5 @@
 public enum BluetoothLinuxError: Error {
-    case noHostController
+    case tooFewHostControllers(String)
     case noServices
     case noCharacteristics
     case bleScanFailed(String)

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -42,7 +42,7 @@ public class BluetoothLinuxTransport: ChatTransport {
 
     public init(
         actAsPeripheral: Bool = true,
-        actAsCentral: Bool = false, // WIP
+        actAsCentral: Bool = true,
         me: ChatUser
     ) throws {
         // Set up controllers. Note that you need at least 2 controller if

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -62,7 +62,7 @@ public class BluetoothLinuxTransport: ChatTransport {
 
     private func handle(peripheralDiscovery scanData: ScanData<Peripheral, GATTCentral.Advertisement>) {
         let peripheral = scanData.peripheral
-        log.info("Discovered peripheral \(peripheral.identifier) (RSSI: \(scanData.rssi), connectable: \(scanData.isConnectable))")
+        log.debug("Discovered peripheral \(peripheral.identifier) (RSSI: \(scanData.rssi), connectable: \(scanData.isConnectable))")
 
         if !nearbyPeripherals.keys.contains(peripheral) {
             do {

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -24,15 +24,19 @@ public class BluetoothLinuxTransport: ChatTransport {
         log.info("Found host controller \(hostController.identifier) with address \(try! hostController.readDeviceAddress())")
 
         central = GATTCentral(hostController: hostController)
-        try central.scan(foundDevice: handle(discovery:))
+        central.newConnection = { (scanData, advReport) in
+            try BluetoothLinux.L2CAPSocket(controllerAddress: scanData.peripheral.identifier)
+        }
+
+        try central.scan(foundDevice: handle(peripheralDiscovery:))
     }
 
     deinit {
         central.stopScan()
     }
 
-    private func handle(discovery: ScanData<Peripheral, GATTCentral.Advertisement>) {
-        log.info("Discovered peripheral \(discovery.peripheral.identifier) (RSSI: \(discovery.rssi), connectable: \(discovery.isConnectable))")
+    private func handle(peripheralDiscovery scanData: ScanData<Peripheral, GATTCentral.Advertisement>) {
+        log.info("Discovered peripheral \(scanData.peripheral.identifier) (RSSI: \(scanData.rssi), connectable: \(scanData.isConnectable))")
     }
 
     public func broadcast(_ raw: String) {

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -81,13 +81,13 @@ public class BluetoothLinuxTransport: ChatTransport {
                     ),
                     .init(
                         uuid: userNameCharacteristicUUID,
-                        // TODO: value
+                        value: me.name.data(using: .utf8) ?? Data(),
                         permissions: [.read],
                         properties: [.read]
                     ),
                     .init(
                         uuid: userIDCharacteristicUUID,
-                        // TODO: value
+                        value: me.id.uuidString.data(using: .utf8) ?? Data(),
                         permissions: [.read],
                         properties: [.read]
                     )

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -44,6 +44,9 @@ public class BluetoothLinuxTransport: ChatTransport {
             log.info("Disconnected from \(peripheral.identifier)")
             nearbyPeripherals[peripheral] = nil
         }
+        central.log = { msg in
+            log.debug("Internal: \(msg)")
+        }
 
         queue.async { [weak self] in
             do {

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -16,13 +16,19 @@ fileprivate let characteristicUUID = UUID(uuidString: "440a594c-3cc2-494a-a08a-b
 
 typealias GATTCentral = GATT.GATTCentral<BluetoothLinux.HostController, BluetoothLinux.L2CAPSocket>
 
-public struct BluetoothLinuxTransport: ChatTransport {
+public class BluetoothLinuxTransport: ChatTransport {
+    private let central: GATTCentral
+
     public init() throws {
         guard let hostController = BluetoothLinux.HostController.default else { throw BluetoothLinuxError.noHostController }
         log.info("Found host controller \(hostController.identifier) with address \(try! hostController.readDeviceAddress())")
 
-        let central = GATTCentral(hostController: hostController)
+        central = GATTCentral(hostController: hostController)
         try central.scan(foundDevice: handle(discovery:))
+    }
+
+    deinit {
+        central.stopScan()
     }
 
     private func handle(discovery: ScanData<Peripheral, GATTCentral.Advertisement>) {

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -8,6 +8,7 @@ import GATT
 
 fileprivate let log = Logger(label: "DistributedChatCLI.BluetoothLinuxTransport")
 
+// TODO: Genericize this class by parameterizing over HostController/L2CAP like GATTCentral/GATTPeripheral
 // TODO: Ideally move these constants into a module shared with the CoreBluetooth version
 // TODO: Share more code with the CoreBluetooth variant (e.g. chunking)
 
@@ -56,9 +57,12 @@ public class BluetoothLinuxTransport: ChatTransport {
         // Set up local GATT peripheral for receiving messages
 
         if let localPeripheral = localPeripheral {
-            // TODO
-            // localPeripheral.newConnection = {
-            // }
+            let serverSocket = try BluetoothLinux.L2CAPSocket.lowEnergyServer()
+
+            localPeripheral.newConnection = {
+                let clientSocket = try serverSocket.waitForConnection()
+                return (socket: clientSocket, central: Central(identifier: clientSocket.address))
+            }
             localPeripheral.log = { msg in
                 log.info("Peripheral (internal): \(msg)")
             }

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -1,0 +1,24 @@
+#if os(Linux)
+import DistributedChat
+import Logging
+import Bluetooth
+import BluetoothLinux
+
+fileprivate let log = Logger(label: "BluetoothLinuxTransport")
+
+public struct BluetoothLinuxTransport: ChatTransport {
+    public init() throws {
+        guard let hostController = BluetoothLinux.HostController.default else { throw BluetoothLinuxError.noHostController }
+        log.info("Found host controller \(hostController)")
+    }
+
+    public func broadcast(_ raw: String) {
+        // TODO
+    }
+
+    public func onReceive(_ handler: @escaping (String) -> Void) {
+        // TODO
+    }
+}
+#endif
+

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -80,11 +80,13 @@ public class BluetoothLinuxTransport: ChatTransport {
                 log.info("Connected to \(peripheral.identifier), discovering services...")
 
                 let services = try localCentral.discoverServices([serviceUUID], for: peripheral)
-                guard let service = services.first else { throw BluetoothLinuxError.noServices }
+                log.debug("Discovered services \(services)")
+                guard let service = services.first(where: { $0.uuid == serviceUUID }) else { throw BluetoothLinuxError.noServices }
                 log.info("Discovered DistributedChat service, discovering characteristics...")
 
                 let characteristics = try localCentral.discoverCharacteristics([inboxCharacteristicUUID], for: service) // TODO: Discover user name/id
-                guard let inboxCharacteristic = characteristics.first else { throw BluetoothLinuxError.noCharacteristics }
+                log.debug("Discovered characteristics \(characteristics)")
+                guard let inboxCharacteristic = characteristics.first(where: { $0.uuid == inboxCharacteristicUUID }) else { throw BluetoothLinuxError.noCharacteristics }
                 log.info("Discovered inbox characteristic")
 
                 state.inboxCharacteristic = inboxCharacteristic

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -40,7 +40,7 @@ public class BluetoothLinuxTransport: ChatTransport {
 
     public init(
         actAsPeripheral: Bool = true,
-        actAsCentral: Bool = true,
+        actAsCentral: Bool = false, // WIP
         me: ChatUser
     ) throws {
         // Set up controllers. Note that you need at least 2 controller if

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -6,7 +6,7 @@ import Bluetooth
 import BluetoothHCI
 import BluetoothLinux
 
-fileprivate let log = Logger(label: "BluetoothLinuxTransport")
+fileprivate let log = Logger(label: "DistributedChatCLI.BluetoothLinuxTransport")
 
 // TODO: Ideally move these constants into a module shared with the CoreBluetooth version
 

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -96,13 +96,16 @@ public class BluetoothLinuxTransport: ChatTransport {
 
             let serverSocket = try BluetoothLinux.L2CAPSocket.lowEnergyServer()
             localPeripheral.newConnection = {
+                log.info("Peripheral: Waiting for connection...")
                 let clientSocket = try serverSocket.waitForConnection()
+                log.info("Peripheral: Connected to central")
                 return (socket: clientSocket, central: Central(identifier: clientSocket.address))
             }
 
             peripheralQueue.async {
                 do {
                     try localPeripheral.start()
+                    log.info("Peripheral: Started, advertising...")
                 } catch {
                     log.error("Peripheral: Starting failed: \(error)")
                 }

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -2,9 +2,8 @@
 import DistributedChat
 import Foundation
 import Logging
-import Bluetooth
-import BluetoothHCI
 import BluetoothLinux
+import GATT
 
 fileprivate let log = Logger(label: "DistributedChatCLI.BluetoothLinuxTransport")
 
@@ -15,25 +14,19 @@ fileprivate let serviceUUID = UUID(uuidString: "59553ceb-2ffa-4018-8a6c-453a5292
 /// Custom UUID specific to the characteristic holding the L2CAP channel's PSM (see below)
 fileprivate let characteristicUUID = UUID(uuidString: "440a594c-3cc2-494a-a08a-be8dd23549ff")!
 
-public struct BluetoothLinuxTransport: ChatTransport {
-    private let l2CapServer: L2CAPSocket
+typealias GATTCentral = GATT.GATTCentral<BluetoothLinux.HostController, BluetoothLinux.L2CAPSocket>
 
+public struct BluetoothLinuxTransport: ChatTransport {
     public init() throws {
         guard let hostController = BluetoothLinux.HostController.default else { throw BluetoothLinuxError.noHostController }
         log.info("Found host controller \(hostController.identifier) with address \(try! hostController.readDeviceAddress())")
 
-        l2CapServer = try L2CAPSocket.lowEnergyServer()
-        log.info("Opened L2CAP server with PSM \(l2CapServer.protocolServiceMultiplexer)")
-
-        do {
-            try hostController.lowEnergyScan(shouldContinue: { true }, foundDevice: handle(report:))
-        } catch {
-            throw BluetoothLinuxError.bleScanFailed("Try relaunching the application using sudo!")
-        }
+        let central = GATTCentral(hostController: hostController)
+        try central.scan(foundDevice: handle(discovery:))
     }
 
-    private func handle(report: HCILEAdvertisingReport.Report) {
-        log.info("Got low energy advertising event: \(report.event) (Address: \(report.address), RSSI: \(report.rssi.map { "\($0)" } ?? "?"))")
+    private func handle(discovery: ScanData<Peripheral, GATTCentral.Advertisement>) {
+        log.info("Discovered peripheral \(discovery.peripheral.identifier) (RSSI: \(discovery.rssi), connectable: \(discovery.isConnectable))")
     }
 
     public func broadcast(_ raw: String) {

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -45,6 +45,7 @@ public class BluetoothLinuxTransport: ChatTransport {
         let requiredCount = [actAsCentral, actAsPeripheral].filter { $0 }.count
         var hostControllers = BluetoothLinux.HostController.controllers
         log.info("Found host controllers \(hostControllers.map(\.identifier))")
+
         if hostControllers.count < requiredCount {
             throw BluetoothLinuxError.tooFewHostControllers("At least \(requiredCount) host controller(s) are required, but only \(hostControllers.count) was/were found.")
         }
@@ -58,6 +59,9 @@ public class BluetoothLinuxTransport: ChatTransport {
             // TODO
             // localPeripheral.newConnection = {
             // }
+            localPeripheral.log = { msg in
+                log.info("Peripheral (internal): \(msg)")
+            }
             localPeripheral.willWrite = { [unowned self] request in
                 log.info("Peripheral: Got write request: \(request)")
                 // TODO

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -62,7 +62,7 @@ public class BluetoothLinuxTransport: ChatTransport {
 
         if let localPeripheral = localPeripheral {
             localPeripheral.log = { msg in
-                log.info("Peripheral (internal): \(msg)")
+                log.debug("Peripheral (internal): \(msg)")
             }
             localPeripheral.willWrite = { [unowned self] request in
                 log.info("Peripheral: Got write request: \(request)")

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -1,11 +1,19 @@
 #if os(Linux)
 import DistributedChat
+import Foundation
 import Logging
 import Bluetooth
 import BluetoothHCI
 import BluetoothLinux
 
 fileprivate let log = Logger(label: "BluetoothLinuxTransport")
+
+// TODO: Ideally move these constants into a module shared with the CoreBluetooth version
+
+/// Custom UUID specifically for the 'Distributed Chat' service
+fileprivate let serviceUUID = UUID(uuidString: "59553ceb-2ffa-4018-8a6c-453a5292044d")!
+/// Custom UUID specific to the characteristic holding the L2CAP channel's PSM (see below)
+fileprivate let characteristicUUID = UUID(uuidString: "440a594c-3cc2-494a-a08a-be8dd23549ff")!
 
 public struct BluetoothLinuxTransport: ChatTransport {
     private let l2CapServer: L2CAPSocket

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -66,7 +66,7 @@ public class BluetoothLinuxTransport: ChatTransport {
             localPeripheral.log = { msg in
                 log.trace("Peripheral (internal): \(msg)")
             }
-            localPeripheral.willWrite = { [unowned self] request in
+            localPeripheral.didWrite = { [unowned self] request in
                 log.debug("Peripheral: Got write request: \(request)")
 
                 if request.uuid == inboxCharacteristicUUID {
@@ -82,7 +82,6 @@ public class BluetoothLinuxTransport: ChatTransport {
                         log.warning("Peripheral: Could not decode write to inbox as UTF-8")
                     }
                 }
-                return nil
             }
 
             try localPeripheral.add(service: .init(

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -35,9 +35,8 @@ public class BluetoothLinuxTransport: ChatTransport {
 
         central = GATTCentral(hostController: hostController)
         central.newConnection = { (scanData, advReport) in
-            try BluetoothLinux.L2CAPSocket(
-                controllerAddress: advReport.address,
-                addressType: .init(lowEnergy: advReport.addressType)
+            try BluetoothLinux.L2CAPSocket.lowEnergyClient(
+                destination: (address: advReport.address, type: .init(lowEnergy: advReport.addressType))
             )
         }
         central.didDisconnect = { [unowned self] peripheral in

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -64,7 +64,7 @@ public class BluetoothLinuxTransport: ChatTransport {
 
         if let localPeripheral = localPeripheral {
             localPeripheral.log = { msg in
-                log.debug("Peripheral (internal): \(msg)")
+                log.trace("Peripheral (internal): \(msg)")
             }
             localPeripheral.willWrite = { [unowned self] request in
                 log.debug("Peripheral: Got write request: \(request)")
@@ -73,7 +73,7 @@ public class BluetoothLinuxTransport: ChatTransport {
                     // TODO: Handle 512 byte (or more precisely: maximumValueLength) chunking
                     if let msgs = String(data: request.value, encoding: .utf8)?.split(separator: "\n").map(String.init) {
                         for msg in msgs {
-                            log.info("Peripheral: Wrote to inbox: \(msg)")
+                            log.debug("Peripheral: Wrote to inbox: \(msg)")
                             for listener in listeners {
                                 listener(msg)
                             }
@@ -111,9 +111,9 @@ public class BluetoothLinuxTransport: ChatTransport {
 
             let serverSocket = try BluetoothLinux.L2CAPSocket.lowEnergyServer()
             localPeripheral.newConnection = {
-                log.info("Peripheral: Waiting for connection...")
+                log.debug("Peripheral: Waiting for connection...")
                 let clientSocket = try serverSocket.waitForConnection()
-                log.info("Peripheral: Connected to central")
+                log.info("Peripheral: Connected to \(clientSocket.address)")
                 return (socket: clientSocket, central: Central(identifier: clientSocket.address))
             }
 
@@ -135,7 +135,7 @@ public class BluetoothLinuxTransport: ChatTransport {
                 nearbyPeripherals[peripheral] = nil
             }
             localCentral.log = { msg in
-                log.debug("Central: (internal) \(msg)")
+                log.trace("Central: (internal) \(msg)")
             }
 
             localCentral.newConnection = { (scanData, advReport) in

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -25,7 +25,7 @@ public struct BluetoothLinuxTransport: ChatTransport {
     }
 
     private func handle(report: HCILEAdvertisingReport.Report) {
-        log.info("Got \(report.event)")
+        log.info("Got low energy advertising event: \(report.event) (Address: \(report.address), RSSI: \(report.rssi.map { "\($0)" } ?? "?"))")
     }
 
     public func broadcast(_ raw: String) {

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -7,9 +7,14 @@ import BluetoothLinux
 fileprivate let log = Logger(label: "BluetoothLinuxTransport")
 
 public struct BluetoothLinuxTransport: ChatTransport {
+    private let l2CapServer: L2CAPSocket
+
     public init() throws {
         guard let hostController = BluetoothLinux.HostController.default else { throw BluetoothLinuxError.noHostController }
-        log.info("Found host controller \(hostController)")
+        log.info("Found host controller \(hostController.identifier) with address \(try! hostController.readDeviceAddress())")
+
+        l2CapServer = try L2CAPSocket.lowEnergyServer()
+        log.info("Opened L2CAP server with PSM \(l2CapServer.protocolServiceMultiplexer)")
     }
 
     public func broadcast(_ raw: String) {

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -34,7 +34,7 @@ public class BluetoothLinuxTransport: ChatTransport {
     private var nearbyPeripherals: [Peripheral: DiscoveredPeripheral] = [:]
 
     private class DiscoveredPeripheral {
-        // TODO: Other characteristics
+        // TODO: Discover and store user name/id here
         var inboxCharacteristic: Characteristic<Peripheral>? = nil
     }
 

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Controller/BluetoothLinuxTransport.swift
@@ -2,6 +2,7 @@
 import DistributedChat
 import Logging
 import Bluetooth
+import BluetoothHCI
 import BluetoothLinux
 
 fileprivate let log = Logger(label: "BluetoothLinuxTransport")
@@ -15,6 +16,16 @@ public struct BluetoothLinuxTransport: ChatTransport {
 
         l2CapServer = try L2CAPSocket.lowEnergyServer()
         log.info("Opened L2CAP server with PSM \(l2CapServer.protocolServiceMultiplexer)")
+
+        do {
+            try hostController.lowEnergyScan(shouldContinue: { true }, foundDevice: handle(report:))
+        } catch {
+            throw BluetoothLinuxError.bleScanFailed("Try relaunching the application using sudo!")
+        }
+    }
+
+    private func handle(report: HCILEAdvertisingReport.Report) {
+        log.info("Got \(report.event)")
     }
 
     public func broadcast(_ raw: String) {

--- a/DistributedChatCLI/Sources/DistributedChatCLI/Utils/LoggerLevel+ExpressibleByArgument.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/Utils/LoggerLevel+ExpressibleByArgument.swift
@@ -1,0 +1,8 @@
+import ArgumentParser
+import Logging
+
+extension Logger.Level: ExpressibleByArgument {
+    public init?(argument: String) {
+        self.init(rawValue: argument.lowercased())
+    }
+}

--- a/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
@@ -5,7 +5,7 @@ import Foundation
 import Logging
 import LineNoise
 
-fileprivate let log = Logger(label: "main")
+fileprivate let log = Logger(label: "DistributedChatCLI.main")
 
 struct DistributedChatCLI: ParsableCommand {
     @Argument(help: "The messaging WebSocket URL of the simulation server to connect to.")

--- a/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
@@ -4,11 +4,6 @@ import DistributedChat
 import Foundation
 import Logging
 
-#if os(Linux)
-import Bluetooth
-import BluetoothLinux
-#endif
-
 struct DistributedChatCLI: ParsableCommand {
     @Argument(help: "The messaging WebSocket URL of the simulation server to connect to.")
     var simulationMessagingURL: URL = URL(string: "ws://localhost:8080/messaging")!
@@ -19,22 +14,20 @@ struct DistributedChatCLI: ParsableCommand {
     @Option(help: "The username to use.")
     var name: String
 
-    func run() {
+    func run() throws {
         LoggingSystem.bootstrap { CLILogHandler(label: $0) }
 
         if bluetooth {
-            runWithBluetoothLE()
+            try runWithBluetoothLE()
         } else {
             runWithSimulationServer()
         }
     }
 
-    private func runWithBluetoothLE() {
+    private func runWithBluetoothLE() throws {
         #if os(Linux)
-        print("Initializing Bluetooth Linux stack...")
-        
-        guard let hostController = BluetoothLinux.HostController.default else { fatalError("No Bluetooth adapters found!") }
-        print("Found host controller \(hostController)")
+        print("Initializing Bluetooth Linux transport...")
+        try runREPL(transport: BluetoothLinuxTransport())
         #else
         print("The Bluetooth stack is currently Linux-only! (TODO: Share the CoreBluetooth-based backend from the iOS app with a potential Mac version of the CLI)")
         #endif

--- a/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
@@ -42,7 +42,7 @@ struct DistributedChatCLI: ParsableCommand {
         SimulationTransport.connect(url: simulationMessagingURL, name: name) { transport in
             DispatchQueue.main.async {
                 log.info("Connected to \(simulationMessagingURL)")
-                try! runREPL(transport: transport)
+                runREPL(transport: transport)
             }
         }
 

--- a/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
@@ -3,6 +3,9 @@ import Dispatch
 import DistributedChat
 import Foundation
 import Logging
+import LineNoise
+
+fileprivate let log = Logger(label: "main")
 
 struct DistributedChatCLI: ParsableCommand {
     @Argument(help: "The messaging WebSocket URL of the simulation server to connect to.")
@@ -26,20 +29,20 @@ struct DistributedChatCLI: ParsableCommand {
 
     private func runWithBluetoothLE() throws {
         #if os(Linux)
-        print("Initializing Bluetooth Linux transport...")
+        log.info("Initializing Bluetooth Linux transport...")
         try runREPL(transport: BluetoothLinuxTransport())
         #else
-        print("The Bluetooth stack is currently Linux-only! (TODO: Share the CoreBluetooth-based backend from the iOS app with a potential Mac version of the CLI)")
+        log.error("The Bluetooth stack is currently Linux-only! (TODO: Share the CoreBluetooth-based backend from the iOS app with a potential Mac version of the CLI)")
         #endif
     }
 
     private func runWithSimulationServer() {
-        print("Connecting to \(simulationMessagingURL)...")
+        log.info("Connecting to \(simulationMessagingURL)...")
 
         SimulationTransport.connect(url: simulationMessagingURL, name: name) { transport in
             DispatchQueue.main.async {
-                print("Connected to \(simulationMessagingURL)")
-                runREPL(transport: transport)
+                log.info("Connected to \(simulationMessagingURL)")
+                try! runREPL(transport: transport)
             }
         }
 

--- a/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
@@ -17,8 +17,11 @@ struct DistributedChatCLI: ParsableCommand {
     @Option(help: "The username to use.")
     var name: String
 
+    @Option(help: "The logging level")
+    var level: Logger.Level = .info
+
     func run() throws {
-        LoggingSystem.bootstrap { CLILogHandler(label: $0) }
+        LoggingSystem.bootstrap { CLILogHandler(label: $0, logLevel: level) }
 
         if bluetooth {
             try runWithBluetoothLE()

--- a/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
@@ -5,15 +5,31 @@ import Foundation
 import Logging
 
 struct DistributedChatCLI: ParsableCommand {
-    @Argument(help: "The messaging WebSocket URL of the simulation server to connect to")
+    @Argument(help: "The messaging WebSocket URL of the simulation server to connect to.")
     var simulationMessagingURL: URL = URL(string: "ws://localhost:8080/messaging")!
 
-    @Option(help: "The username to use")
+    @Flag(help: "Use Bluetooth LE-based transport instead of the simulation server. This enables communication with 'real' iOS nodes. Currently only supported on Linux.")
+    var bluetooth: Bool = false
+
+    @Option(help: "The username to use.")
     var name: String
 
     func run() {
         LoggingSystem.bootstrap { CLILogHandler(label: $0) }
 
+        if bluetooth {
+            runWithBluetoothLE()
+        } else {
+            runWithSimulationServer()
+        }
+    }
+
+    private func runWithBluetoothLE() {
+        print("Initializing Bluetooth Linux stack...")
+        // TODO
+    }
+
+    private func runWithSimulationServer() {
         print("Connecting to \(simulationMessagingURL)...")
 
         SimulationTransport.connect(url: simulationMessagingURL, name: name) { transport in

--- a/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
@@ -21,7 +21,9 @@ struct DistributedChatCLI: ParsableCommand {
     var level: Logger.Level = .info
 
     func run() throws {
-        LoggingSystem.bootstrap { CLILogHandler(label: $0, logLevel: level) }
+        LoggingSystem.bootstrap { label in
+            CLILogHandler(label: label, logLevel: label.starts(with: "DistributedChatCLI.") ? level : .info)
+        }
 
         if bluetooth {
             try runWithBluetoothLE()

--- a/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
+++ b/DistributedChatCLI/Sources/DistributedChatCLI/main.swift
@@ -4,6 +4,11 @@ import DistributedChat
 import Foundation
 import Logging
 
+#if os(Linux)
+import Bluetooth
+import BluetoothLinux
+#endif
+
 struct DistributedChatCLI: ParsableCommand {
     @Argument(help: "The messaging WebSocket URL of the simulation server to connect to.")
     var simulationMessagingURL: URL = URL(string: "ws://localhost:8080/messaging")!
@@ -25,8 +30,14 @@ struct DistributedChatCLI: ParsableCommand {
     }
 
     private func runWithBluetoothLE() {
+        #if os(Linux)
         print("Initializing Bluetooth Linux stack...")
-        // TODO
+        
+        guard let hostController = BluetoothLinux.HostController.default else { fatalError("No Bluetooth adapters found!") }
+        print("Found host controller \(hostController)")
+        #else
+        print("The Bluetooth stack is currently Linux-only! (TODO: Share the CoreBluetooth-based backend from the iOS app with a potential Mac version of the CLI)")
+        #endif
     }
 
     private func runWithSimulationServer() {


### PR DESCRIPTION
### Fixes #7 

Use `BluetoothLinux` to implement a BLE-based transport in the CLI. To use it, a `--bluetooth` flag is added (which uses BLE instead of the simulation server when set).

Todo:
- [x] Use `BluetoothLinux` to connect to host controller and scan for advertisements
- [x] Set up GATT central
    - [x] Scan for devices
    - [x] Connect to devices and transmit sent messages to them
- [x] Set up GATT peripheral
    - [x] Expose DistributedChat service with message inbox, user name and user id
    - [ ] Make sure that central and peripheral can run in parallel